### PR TITLE
Python 3.6 is unhappy without arg names

### DIFF
--- a/json_codegen/generators/python3object.py
+++ b/json_codegen/generators/python3object.py
@@ -239,7 +239,7 @@ class Python3ObjectGenerator(object):
         fn_body = [
             ast.Return(
                 ast.Attribute(
-                    ast.Call(
+                    value=ast.Call(
                         func=ast.Attribute(
                             value=ast.Call(
                                 func=ast.Name(id=schema.name),


### PR DESCRIPTION
Found the bug in https://travis-ci.org/expobrain/json-schema-codegen/jobs/466415425

```
E       TypeError: Attribute constructor takes either 0 or 3 positional arguments
```

The `Attribute` constructor was expecting a keyword + I'd just given it a positional arg.