### PR TITLE
Fixed definition of array types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- [#23](https://github.com/expobrain/json-schema-codegen/pull/23) Use list validation in the schemas to generate lists instead of generating them from a tuple validation. See https://json-schema.org/understanding-json-schema/reference/array.html#items.
+
 ### Trivial/internal changes
 
 - [#21](https://github.com/expobrain/json-schema-codegen/pull/21) Fixed anchors in README

--- a/json_codegen/astlib/javascript.py
+++ b/json_codegen/astlib/javascript.py
@@ -1,4 +1,8 @@
+from typing import NewType, Dict
 import json
+
+
+AST = NewType("AST", Dict)
 
 
 def File(program=None, comments=None):

--- a/json_codegen/generators/javascript_flow.py
+++ b/json_codegen/generators/javascript_flow.py
@@ -69,8 +69,15 @@ class JavaScriptFlowGenerator(SchemaParser, BaseGenerator):
 
         consequent = ast.MemberExpression(ast.Identifier("data"), property_=ast.Identifier(name))
 
-        if len(items) == 1 and "$ref" in items[0]:
-            ref_key = items[0]["$ref"]
+        if isinstance(items, dict) and "oneOf" in items:
+            one_of = items["oneOf"][0]
+
+            if "$ref" not in one_of:
+                raise NotImplementedError(
+                    "Only 'oneOf' with '$ref's are supported: {}".format(one_of)
+                )
+
+            ref_key = one_of["$ref"]
             ref = self.definitions[ref_key]
 
             if not self.definition_is_primitive_alias(ref):
@@ -85,6 +92,8 @@ class JavaScriptFlowGenerator(SchemaParser, BaseGenerator):
                         )
                     ],
                 )
+        elif isinstance(items, list) and len(items):
+            raise NotImplementedError("Tuples not implemented yet: {}".format(items))
 
         # Alternate expression
         alternate = ast.ArrayExpression(

--- a/json_codegen/types.py
+++ b/json_codegen/types.py
@@ -1,0 +1,7 @@
+from typing import Dict, List, NewType
+
+
+DefinitionType = NewType("DefinitionType", Dict)
+PropertyType = NewType("PropertyType", Dict)
+PropertiesType = NewType("PropertiesType", List[PropertyType])
+RequiredType = NewType("RequiredType", List)

--- a/tests/fixtures/flow/array_property_default.ast.json
+++ b/tests/fixtures/flow/array_property_default.ast.json
@@ -30,7 +30,7 @@
                   "type": "TypeParameterInstantiation",
                   "params": [
                     {
-                      "type": "ExistsTypeAnnotation"
+                      "type": "AnyTypeAnnotation"
                     }
                   ]
                 },

--- a/tests/fixtures/flow/array_property_default.template.js
+++ b/tests/fixtures/flow/array_property_default.template.js
@@ -1,7 +1,7 @@
 // @flow
 
 declare type Test = {
-  x: Array<*>,
+  x: Array<any>,
 
   constructor(data: ?Object): void
 };

--- a/tests/fixtures/javascript_flow/array_property_default.ast.json
+++ b/tests/fixtures/javascript_flow/array_property_default.ast.json
@@ -35,7 +35,7 @@
                       "type": "TypeParameterInstantiation",
                       "params": [
                         {
-                          "type": "ExistsTypeAnnotation"
+                          "type": "AnyTypeAnnotation"
                         }
                       ]
                     },

--- a/tests/fixtures/javascript_flow/array_property_default.template.js
+++ b/tests/fixtures/javascript_flow/array_property_default.template.js
@@ -1,7 +1,7 @@
 // @flow
 
 export class Test {
-  x: Array<*>;
+  x: Array<any>;
 
   constructor(data: Object = {}) {
     this.x = Array.isArray(data.x) ? data.x : [42];

--- a/tests/fixtures/schemas/array_items_ref.schema.json
+++ b/tests/fixtures/schemas/array_items_ref.schema.json
@@ -6,7 +6,10 @@
   "properties": {
     "x": {
       "type": "array",
-      "items": [{ "$ref": "#/definitions/MyType" }],
+      "items": {
+        "type": "object",
+        "oneOf": [{ "$ref": "#/definitions/MyType" }]
+      },
       "default": []
     }
   },

--- a/tests/fixtures/schemas/array_items_ref_as_alias.schema.json
+++ b/tests/fixtures/schemas/array_items_ref_as_alias.schema.json
@@ -6,7 +6,10 @@
   "properties": {
     "x": {
       "type": "array",
-      "items": [{ "$ref": "#/definitions/MyType" }],
+      "items": {
+        "type": "object",
+        "oneOf": [{ "$ref": "#/definitions/MyType" }]
+      },
       "default": []
     }
   },

--- a/tests/fixtures/schemas/array_items_ref_as_scalar.schema.json
+++ b/tests/fixtures/schemas/array_items_ref_as_scalar.schema.json
@@ -6,7 +6,7 @@
   "properties": {
     "x": {
       "type": "array",
-      "items": [{ "type": "string" }],
+      "items": { "type": "string" },
       "default": []
     }
   }

--- a/tests/fixtures/schemas/object_property_default.schema.json
+++ b/tests/fixtures/schemas/object_property_default.schema.json
@@ -3,6 +3,9 @@
   "title": "Test",
   "type": "object",
   "properties": {
-    "x": { "type": "object", "default": { "x": 42 } }
+    "x": {
+      "type": "object",
+      "default": { "x": 42 }
+    }
   }
 }

--- a/tests/generator_python2_test.py
+++ b/tests/generator_python2_test.py
@@ -35,6 +35,7 @@ def test_generate(schema_filename):
     result_ast = astor.dump_tree(result)
     expected = astor.dump_tree(fixture)
 
-    print(expected)
+    print(astor.to_source(result))
+    print(schema_filename.read_text())
 
     assert result_ast == expected

--- a/tests/generator_python3_marshmallow_test.py
+++ b/tests/generator_python3_marshmallow_test.py
@@ -42,6 +42,6 @@ def test_generate(schema_filename):
     result_ast = astor.dump_tree(result)
     expected = astor.dump_tree(fixture)
 
-    print(expected)
+    print(astor.to_source(result))
 
     assert result_ast == expected


### PR DESCRIPTION
The `array` type has an `items` keyword which can be a single item type or a list of types: when `items` is dict a list must be generated, when instead is a list a tuple must be generated.

The code was generating a list when instead a tuple should be generated.

Fixed the original test schema.

See https://json-schema.org/understanding-json-schema/reference/array.html#items.