### PR TITLE
Fixed error when object type without default value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.1
+
+### Bug fixes
+
+- [#25](https://github.com/expobrain/json-schema-codegen/pull/25) Fixed error when object type without default value
+
 ## v0.4.0
 
 ### Breaking changes

--- a/json_codegen/generators/python3.py
+++ b/json_codegen/generators/python3.py
@@ -235,12 +235,8 @@ class Python3Generator(SchemaParser, BaseGenerator):
                         value=ast.Tuple(elts=[ast.Name(id="str"), ast.Name(id=object_name)])
                     ),
                 )
-            elif "default" in property_:
-                annotation = ast.Name(id="Dict")
             else:
-                raise NotImplementedError(
-                    "Definition for type 'object' not supported".format(property_)
-                )
+                annotation = ast.Name(id="Dict")
 
         # ... map array
         elif property_type == "array":

--- a/tests/fixtures/flow/object_property.ast.json
+++ b/tests/fixtures/flow/object_property.ast.json
@@ -1,0 +1,101 @@
+{
+  "type": "File",
+  "program": {
+    "type": "Program",
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "DeclareTypeAlias",
+        "id": {
+          "type": "Identifier",
+          "name": "Test"
+        },
+        "typeParameters": null,
+        "right": {
+          "type": "ObjectTypeAnnotation",
+          "callProperties": [],
+          "properties": [
+            {
+              "type": "ObjectTypeProperty",
+              "key": {
+                "type": "Identifier",
+                "name": "x"
+              },
+              "static": false,
+              "kind": "init",
+              "method": false,
+              "value": {
+                "type": "NullableTypeAnnotation",
+                "typeAnnotation": {
+                  "type": "GenericTypeAnnotation",
+                  "typeParameters": null,
+                  "id": {
+                    "type": "Identifier",
+                    "name": "Object"
+                  }
+                }
+              },
+              "variance": null,
+              "optional": false
+            },
+            {
+              "type": "ObjectTypeProperty",
+              "key": {
+                "type": "Identifier",
+                "name": "constructor"
+              },
+              "static": false,
+              "kind": "init",
+              "method": true,
+              "value": {
+                "type": "FunctionTypeAnnotation",
+                "params": [
+                  {
+                    "type": "FunctionTypeParam",
+                    "name": {
+                      "type": "Identifier",
+                      "name": "data"
+                    },
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "NullableTypeAnnotation",
+                      "typeAnnotation": {
+                        "type": "GenericTypeAnnotation",
+                        "typeParameters": null,
+                        "id": {
+                          "type": "Identifier",
+                          "name": "Object"
+                        }
+                      }
+                    }
+                  }
+                ],
+                "rest": null,
+                "typeParameters": null,
+                "returnType": {
+                  "type": "VoidTypeAnnotation"
+                }
+              },
+              "optional": false
+            }
+          ],
+          "indexers": [],
+          "exact": false
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow"
+          }
+        ]
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow"
+    }
+  ]
+}

--- a/tests/fixtures/flow/object_property.template.js
+++ b/tests/fixtures/flow/object_property.template.js
@@ -1,0 +1,7 @@
+// @flow
+
+declare type Test = {
+  x: ?Object,
+
+  constructor(data: ?Object): void
+};

--- a/tests/fixtures/javascript_flow/object_property.ast.json
+++ b/tests/fixtures/javascript_flow/object_property.ast.json
@@ -1,0 +1,139 @@
+{
+  "type": "File",
+  "program": {
+    "type": "Program",
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ExportNamedDeclaration",
+        "specifiers": [],
+        "source": null,
+        "declaration": {
+          "type": "ClassDeclaration",
+          "id": {
+            "type": "Identifier",
+            "name": "Test"
+          },
+          "superClass": null,
+          "body": {
+            "type": "ClassBody",
+            "body": [
+              {
+                "type": "ClassProperty",
+                "static": false,
+                "key": {
+                  "type": "Identifier",
+                  "name": "x"
+                },
+                "computed": false,
+                "variance": null,
+                "typeAnnotation": {
+                  "type": "TypeAnnotation",
+                  "typeAnnotation": {
+                    "type": "NullableTypeAnnotation",
+                    "typeAnnotation": {
+                      "type": "GenericTypeAnnotation",
+                      "typeParameters": null,
+                      "id": {
+                        "type": "Identifier",
+                        "name": "Object"
+                      }
+                    }
+                  }
+                },
+                "value": null
+              },
+              {
+                "type": "ClassMethod",
+                "static": false,
+                "key": {
+                  "type": "Identifier",
+                  "name": "constructor"
+                },
+                "computed": false,
+                "kind": "constructor",
+                "id": null,
+                "generator": false,
+                "async": false,
+                "params": [
+                  {
+                    "type": "AssignmentPattern",
+                    "left": {
+                      "type": "Identifier",
+                      "name": "data",
+                      "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "typeAnnotation": {
+                          "type": "GenericTypeAnnotation",
+                          "typeParameters": null,
+                          "id": {
+                            "type": "Identifier",
+                            "name": "Object"
+                          }
+                        }
+                      }
+                    },
+                    "right": {
+                      "type": "ObjectExpression",
+                      "properties": []
+                    }
+                  }
+                ],
+                "body": {
+                  "type": "BlockStatement",
+                  "body": [
+                    {
+                      "type": "ExpressionStatement",
+                      "expression": {
+                        "type": "AssignmentExpression",
+                        "operator": "=",
+                        "left": {
+                          "type": "MemberExpression",
+                          "object": {
+                            "type": "ThisExpression"
+                          },
+                          "property": {
+                            "type": "Identifier",
+                            "name": "x"
+                          },
+                          "computed": false
+                        },
+                        "right": {
+                          "type": "MemberExpression",
+                          "object": {
+                            "type": "Identifier",
+                            "name": "data"
+                          },
+                          "property": {
+                            "type": "Identifier",
+                            "name": "x"
+                          },
+                          "computed": false
+                        }
+                      }
+                    }
+                  ],
+                  "directives": []
+                }
+              }
+            ]
+          }
+        },
+        "leadingComments": [
+          {
+            "type": "CommentLine",
+            "value": " @flow"
+          }
+        ],
+        "exportKind": "value"
+      }
+    ],
+    "directives": []
+  },
+  "comments": [
+    {
+      "type": "CommentLine",
+      "value": " @flow"
+    }
+  ]
+}

--- a/tests/fixtures/javascript_flow/object_property.template.js
+++ b/tests/fixtures/javascript_flow/object_property.template.js
@@ -1,0 +1,9 @@
+// @flow
+
+export class Test {
+  x: ?Object;
+
+  constructor(data: Object = {}) {
+    this.x = data.x;
+  }
+}

--- a/tests/fixtures/python2/object_property.py
+++ b/tests/fixtures/python2/object_property.py
@@ -1,0 +1,8 @@
+from __future__ import unicode_literals, print_function, division
+
+
+class Test(object):
+    def __init__(self, data=None):
+        data = data or {}
+
+        self.x = data.get("x")

--- a/tests/fixtures/python3/object_property.py
+++ b/tests/fixtures/python3/object_property.py
@@ -1,0 +1,8 @@
+from typing import Dict, Optional, List, Any
+
+
+class Test(object):
+    def __init__(self, data: Optional[Dict] = None):
+        data = data or {}
+
+        self.x: Optional[Dict] = data.get("x")

--- a/tests/fixtures/schemas/object_property.schema.json
+++ b/tests/fixtures/schemas/object_property.schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Test",
+  "type": "object",
+  "properties": {
+    "x": { "type": "object" }
+  }
+}


### PR DESCRIPTION
When an object type is defined without a default value, i.e.:

```json
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Test",
  "type": "object",
  "properties": {
    "x": { "type": "object" }
  }
}
```

code generation fails.